### PR TITLE
Fix color and all variants strata

### DIFF
--- a/qq.py
+++ b/qq.py
@@ -311,9 +311,10 @@ if __name__ == "__main__":
     ax.fill_between(x_ci, lower_ci, upper_ci, color="0.8")
     ax.plot([0,x_ci[-1]], [0,x_ci[-1]], ls='--', lw=1, marker=' ', color="k")
     # plot all data
-    ax.plot(x, y, ls='-', lw=1, marker=' ', label="all variants", color='C0')
-    if args.top_as_dot > 0:
-        ax.plot(x_dot, y_dot, ls=' ', marker='.', ms=1, color='C0')
+    if df_strata is None:
+        ax.plot(x, y, ls='-', lw=1, marker=' ', label="all variants", color='C0')
+        if args.top_as_dot > 0:
+            ax.plot(x_dot, y_dot, ls=' ', marker='.', ms=1, color='C0')
 
     # plot strata
     if not df_strata is None:
@@ -321,7 +322,7 @@ if __name__ == "__main__":
             i = df_strata.index[df_strata[stratum_id]]
             x, y, x_dot, y_dot = get_xy_from_p(df_sumstats.loc[i,args.p],
                 args.top_as_dot, df_sumstats.loc[i,"weights"])
-            color = "C%d" % (j+1)
+            color = "C%d" % ((j%9)+1) 
             ax.plot(x, y, ls='-', lw=1, marker=' ', label=stratum_id, color=color)
             if args.top_as_dot > 0:
                 ax.plot(x_dot, y_dot, ls=' ', marker='.', ms=1, color=color)

--- a/sumstats.py
+++ b/sumstats.py
@@ -1354,11 +1354,15 @@ def touch(fname, times=None):
     with open(fname, 'a'):
         os.utime(fname, times)
 
+def tar_filter(tarinfo):
+    if os.path.basename(tarinfo.name).startswith('sumstats'): return None
+    return tarinfo
+
 def clump_cleanup(args, log):
     temp_out = args.out + '.temp'
     log.log('Saving intermediate files to {out}.temp.tar.gz'.format(out=args.out))
     with tarfile.open('{out}.temp.tar.gz'.format(out=args.out), "w:gz") as tar:
-        tar.add(temp_out, arcname=os.path.basename(temp_out), exclude=lambda filename : os.path.basename(filename).startswith('sumstats'))
+        tar.add(temp_out, arcname=os.path.basename(temp_out), filter=tar_filter)
     rmtree(temp_out)
 
 def make_clump(args, log):


### PR DESCRIPTION
It's very convenient to have strata on QQ plots, thanks for this feature! This are some minor changes. Changing the color is just to avoid the crash when there is more than 9 colors. RE all variants strata, in some cases I'd like to plot without it, for example to show only a specific chromosome. We could have introduce option to plot all variants, but it's also possible fr the user to implement it "manually", by listing all potential categories.