### PR TITLE
Update sumstats.py zscore (deprecated 'float' alias)

### DIFF
--- a/sumstats.py
+++ b/sumstats.py
@@ -1023,7 +1023,7 @@ def make_zscore(args, log):
         # if signed_effect is true, take effect column as string to handle correctly
         # case of truncated numbers, e.g.: 0.00 and -0.00 should have different sign
         signed_effect = False if args.effect == cols.OR else True
-        effect_col_dtype_map = {args.effect: (str if signed_effect else np.float)}
+        effect_col_dtype_map = {args.effect: (str if signed_effect else float)}
 
     log.log('Reading summary statistics file {}...'.format(args.sumstats))
     reader = pd.read_csv(args.sumstats, sep='\t', chunksize=args.chunksize,


### PR DESCRIPTION
Running `./sumstats.py zscore --sumstats /path/sumstats.csv --out /path/sumstats_Z.csv` with Python/3.11.3-GCCcore-12.3.0 calls (line 1026)
```
effect_col_dtype_map = {args.effect: (str if signed_effect else np.float)} 
```
giving the error
```
`np.float` was a deprecated alias for the builtin `float`. 
To avoid this error in existing code, use `float` by itself. 
Doing this will not modify any behavior and is safe. 
If you specifically wanted the numpy scalar type, use `np.float64` here. 
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.
```